### PR TITLE
Use Github actions to deploy to package registry

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,23 @@
+name: Docker Image CI
+
+on:
+  push:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag docker.pkg.github.com/hzdr/labhub/app:latest
+    - name: Login to the GitHub Package Registry
+      if: github.ref == 'refs/heads/master'
+      run: docker login -p ${{ secrets.GITHUB_TOKEN }} -u ${{ github.actor }} docker.pkg.github.com
+    - name: Publish the image
+      if: github.ref == 'refs/heads/master'
+      run: docker push docker.pkg.github.com/hzdr/labhub/app:latest


### PR DESCRIPTION
As long as the changes are not available in the upstream repository we need to build our own docker images nightly. I gave GitHub actions a try and implemented a basic solution for this repository.

* Builds images on pushes to the repository
* Comes with a schedule job, that runs on the default branch and pushes the image to the registry