### PR TITLE
Try GitHub pull request trigger actions

### DIFF
--- a/LabHub.toml
+++ b/LabHub.toml
@@ -40,9 +40,7 @@ gitlab_repo = "brndnmtthws-oss/conky"
 [pull_request_event_trigger_actions]
 # list of enabled trigger actions
 enabled_trigger_actions = [
-    "review_requested",
     "synchronize",
     "opened",
     "reopened",
-    "closed",
 ]

--- a/LabHub.toml
+++ b/LabHub.toml
@@ -43,4 +43,5 @@ enabled_trigger_actions = [
     "synchronize",
     "opened",
     "reopened",
+    "merged",
 ]

--- a/LabHub.toml
+++ b/LabHub.toml
@@ -43,5 +43,5 @@ enabled_trigger_actions = [
     "synchronize",
     "opened",
     "reopened",
-    "merged",
+    "closed",
 ]

--- a/LabHub.toml
+++ b/LabHub.toml
@@ -42,4 +42,7 @@ gitlab_repo = "brndnmtthws-oss/conky"
 enabled_trigger_actions = [
     "review_requested",
     "synchronize",
+    "opened",
+    "reopened",
+    "closed",
 ]

--- a/src/actions/actions.rs
+++ b/src/actions/actions.rs
@@ -2,10 +2,20 @@
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ActionValue {
-    Synchronize,
-    Opened,
-    Reopened,
+    Assigned,
     Closed,
+    Edited,
+    Labeled,
+    Locked,
+    Opened,
+    ReadyForReview,
+    Reopened,
+    ReviewRequested,
+    ReviewRequestRemoved,
+    Synchronize,
+    Unassigned,
+    Unlabeled,
+    Unlocked,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/actions/actions.rs
+++ b/src/actions/actions.rs
@@ -5,7 +5,7 @@ pub enum ActionValue {
     Synchronize,
     Opened,
     Reopened,
-    Merged,
+    Closed,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/actions/actions.rs
+++ b/src/actions/actions.rs
@@ -4,6 +4,9 @@
 pub enum ActionValue {
     ReviewRequested,
     Synchronize,
+    Opened,
+    Reopened,
+    Closed,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/actions/actions.rs
+++ b/src/actions/actions.rs
@@ -2,11 +2,9 @@
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ActionValue {
-    ReviewRequested,
     Synchronize,
     Opened,
     Reopened,
-    Closed,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/actions/actions.rs
+++ b/src/actions/actions.rs
@@ -5,6 +5,7 @@ pub enum ActionValue {
     Synchronize,
     Opened,
     Reopened,
+    Merged,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -518,12 +518,8 @@ pub fn handle_event_body(event_type: &str, body: &str) -> Result<String, Request
                 let pr: github::PullRequest = serde_json::from_str(body)?;
                 // custom check if pull request event trigger is enabled in config file
                 if config::action_enabled(pr.action.as_ref()?) {
-                    if pr.action.as_ref() == "closed" && pr.pull_request.merged == false {
-                        info!("Event trigger action 'closed' not enabled, if 'merged' is false. Skipping event.");
-                    } else {
-                        info!("PullRequest action={}", pr.action.as_ref()?);
-                        thread::spawn(move || handle_pr(pr));
-                    }
+                    info!("PullRequest action={}", pr.action.as_ref()?);
+                    thread::spawn(move || handle_pr(pr));
                 } else {
                     info!("Event trigger action not enabled. Skipping event.");
                 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -518,8 +518,12 @@ pub fn handle_event_body(event_type: &str, body: &str) -> Result<String, Request
                 let pr: github::PullRequest = serde_json::from_str(body)?;
                 // custom check if pull request event trigger is enabled in config file
                 if config::action_enabled(pr.action.as_ref()?) {
-                    info!("PullRequest action={}", pr.action.as_ref()?);
-                    thread::spawn(move || handle_pr(pr));
+                    if pr.action.as_ref() == "closed" && pr.pull_request.merged == false {
+                        info!("Event trigger action 'closed' not enabled, if 'merged' is false. Skipping event.");
+                    } else {
+                        info!("PullRequest action={}", pr.action.as_ref()?);
+                        thread::spawn(move || handle_pr(pr));
+                    }
                 } else {
                     info!("Event trigger action not enabled. Skipping event.");
                 }


### PR DESCRIPTION
Changed GitHub action events which trigger pipelines in LabHub TOML file

The actions which trigger pipelines are 
* synchronize
* opened
* reopened
* closed

Please check if that is correct.

All possible actions are listed here:
https://developer.github.com/v3/activity/events/types/#pullrequestevent
